### PR TITLE
Updating Publish Command

### DIFF
--- a/deploy.cmd
+++ b/deploy.cmd
@@ -57,7 +57,7 @@ echo Handling ASP.NET Core Web Application deployment with MSBuild16.
 call :ExecuteCmd dotnet restore "%DEPLOYMENT_SOURCE%\dotnetcore31web.sln" 
 IF !ERRORLEVEL! NEQ 0 goto error
 
-call :ExecuteCmd dotnet publish "%DEPLOYMENT_SOURCE%\dotnetcore31web.sln" --output "%DEPLOYMENT_TEMP%" --configuration Release
+call :ExecuteCmd dotnet publish "%DEPLOYMENT_SOURCE%\dotnetcore31web.sln" --property:PublishDir="%DEPLOYMENT_TEMP%" --configuration Release
 IF !ERRORLEVEL! NEQ 0 goto error
 
 :: 2. KuduSync


### PR DESCRIPTION
This is to fix the error NETSDK1194: The "--output" option isn't supported when building a solution. which was causing kudu-ci failures.

Making the fix as per this blog: https://steven-giesel.com/blogPost/554ba273-9594-4d55-aac2-1366e28954b3